### PR TITLE
Removed slide animation when transitioning screens

### DIFF
--- a/App/Avalanche/Avalanche/AvalancheNavigation.cs
+++ b/App/Avalanche/Avalanche/AvalancheNavigation.cs
@@ -43,7 +43,7 @@ namespace Avalanche
                     return;
                 }
             }
-            App.Navigation.Navigation.PushAsync( new MainPage( "page/" + resource, parameter ) );
+            App.Navigation.Navigation.PushAsync( new MainPage( "page/" + resource, parameter ), false );
         }
 
         public static void RemovePage()
@@ -62,7 +62,7 @@ namespace Avalanche
                     return;
                 }
             }
-            await App.Navigation.Navigation.PushAsync( new MainPage( "page/" + resource, parameter ) );
+            await App.Navigation.Navigation.PushAsync( new MainPage( "page/" + resource, parameter ), false );
             App.Navigation.Navigation.RemovePage( currentPage );
         }
 


### PR DESCRIPTION
When transitioning from one screen to another, there is a screen slide animation. By changing this setting, it removes the animation which make it seem more responsive.